### PR TITLE
Automatically register C# services

### DIFF
--- a/JobIntro.Core/JobIntro.Core.csproj
+++ b/JobIntro.Core/JobIntro.Core.csproj
@@ -6,4 +6,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    </ItemGroup>
+
 </Project>

--- a/JobIntro.Core/ServiceRegistration/Interfaces/IHasImplementationFactory.cs
+++ b/JobIntro.Core/ServiceRegistration/Interfaces/IHasImplementationFactory.cs
@@ -1,0 +1,12 @@
+namespace JobIntro.Core.ServiceRegistration.Interfaces;
+
+/// <summary>
+/// You can use this interface if you have a different registration strategy, for example,
+/// if you want to register a concrete instance of an object.
+///
+/// Note: Provide a parameterless constructor for your class
+/// </summary>
+public interface IHasImplementationFactory
+{
+    Func<IServiceProvider, object> GetFactory();
+}

--- a/JobIntro.Core/ServiceRegistration/Interfaces/IJobIntroService.cs
+++ b/JobIntro.Core/ServiceRegistration/Interfaces/IJobIntroService.cs
@@ -1,0 +1,6 @@
+namespace JobIntro.Core.ServiceRegistration.Interfaces;
+
+public interface IJobIntroService
+{
+    
+}

--- a/JobIntro.Core/ServiceRegistration/Interfaces/IJobIntroService.cs
+++ b/JobIntro.Core/ServiceRegistration/Interfaces/IJobIntroService.cs
@@ -1,5 +1,8 @@
 namespace JobIntro.Core.ServiceRegistration.Interfaces;
 
+/// <summary>
+/// Basic interface for automated service enrollment
+/// </summary>
 public interface IJobIntroService
 {
     

--- a/JobIntro.Core/ServiceRegistration/Interfaces/IScoped.cs
+++ b/JobIntro.Core/ServiceRegistration/Interfaces/IScoped.cs
@@ -1,10 +1,17 @@
 namespace JobIntro.Core.ServiceRegistration.Interfaces;
 
+/// <summary>
+/// Interface for the registration of a scoped service
+/// </summary>
 public interface IScoped : IJobIntroService
 {
     
 }
 
+/// <summary>
+/// Interface for the registration of a scoped service
+/// </summary>
+/// <typeparam name="T"></typeparam>
 public interface IScoped<T> : IJobIntroService
 {
     

--- a/JobIntro.Core/ServiceRegistration/Interfaces/IScoped.cs
+++ b/JobIntro.Core/ServiceRegistration/Interfaces/IScoped.cs
@@ -1,0 +1,11 @@
+namespace JobIntro.Core.ServiceRegistration.Interfaces;
+
+public interface IScoped : IJobIntroService
+{
+    
+}
+
+public interface IScoped<T> : IJobIntroService
+{
+    
+}

--- a/JobIntro.Core/ServiceRegistration/Interfaces/ISingleton.cs
+++ b/JobIntro.Core/ServiceRegistration/Interfaces/ISingleton.cs
@@ -1,0 +1,11 @@
+namespace JobIntro.Core.ServiceRegistration.Interfaces;
+
+public interface ISingleton : IJobIntroService
+{
+
+}
+
+public interface ISingleton<T> : IJobIntroService
+{
+
+}

--- a/JobIntro.Core/ServiceRegistration/Interfaces/ISingleton.cs
+++ b/JobIntro.Core/ServiceRegistration/Interfaces/ISingleton.cs
@@ -1,10 +1,17 @@
 namespace JobIntro.Core.ServiceRegistration.Interfaces;
 
+/// <summary>
+/// Interface for the registration of a singleton service
+/// </summary>
 public interface ISingleton : IJobIntroService
 {
 
 }
 
+/// <summary>
+/// Interface for the registration of a singleton service
+/// </summary>
+/// <typeparam name="T"></typeparam>
 public interface ISingleton<T> : IJobIntroService
 {
 

--- a/JobIntro.Core/ServiceRegistration/Interfaces/ITransient.cs
+++ b/JobIntro.Core/ServiceRegistration/Interfaces/ITransient.cs
@@ -1,0 +1,11 @@
+namespace JobIntro.Core.ServiceRegistration.Interfaces;
+
+public interface ITransient : IJobIntroService
+{
+    
+}
+
+public interface ITransient<T> : IJobIntroService
+{
+    
+}

--- a/JobIntro.Core/ServiceRegistration/Interfaces/ITransient.cs
+++ b/JobIntro.Core/ServiceRegistration/Interfaces/ITransient.cs
@@ -1,10 +1,17 @@
 namespace JobIntro.Core.ServiceRegistration.Interfaces;
 
+/// <summary>
+/// Interface for the registration of a transient service
+/// </summary>
 public interface ITransient : IJobIntroService
 {
     
 }
 
+/// <summary>
+/// Interface for the registration of a transient service
+/// </summary>
+/// <typeparam name="T"></typeparam>
 public interface ITransient<T> : IJobIntroService
 {
     

--- a/JobIntro.Core/ServiceRegistration/ServiceCollectionExtensions.cs
+++ b/JobIntro.Core/ServiceRegistration/ServiceCollectionExtensions.cs
@@ -1,0 +1,103 @@
+using System.Reflection;
+using JobIntro.Core.ServiceRegistration.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JobIntro.Core.ServiceRegistration;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers all items for the calling assembly
+    /// </summary>
+    public static IServiceCollection AddServiceForCallingAssembly(this IServiceCollection services)
+    {
+        var callingAssembly = Assembly.GetCallingAssembly();
+
+        return AddService(services, callingAssembly);
+    }
+
+    private static void RegisterWithTypes(
+        IServiceCollection services, 
+        Type serviceType, 
+        Type implementationType,
+        ServiceLifetime lifetime)
+    {
+        var descriptor = new ServiceDescriptor(serviceType, implementationType, lifetime);
+
+        services.Add(descriptor);
+    }
+
+    private static void RegisterWithImplementationFactory(
+        IServiceCollection services,
+        Type implementationType,
+        ServiceLifetime lifetime)
+    {
+        var classInstance = Activator.CreateInstance(implementationType);
+
+        var invokedMethod = implementationType
+            .GetMethod(nameof(IHasImplementationFactory.GetFactory))
+            ?.Invoke(classInstance, null);
+        
+        if (invokedMethod is not Func<IServiceProvider, object> factory)
+        {
+            throw new NullReferenceException("The factory for services must not be null");
+        }
+        
+        var descriptor = new ServiceDescriptor(implementationType, factory, lifetime);
+
+        services.Add(descriptor);
+    }
+
+    private static (Type serviceType, Type implementationType) GetTypes(Type serviceToRegister)
+    {
+        var genericInterface = serviceToRegister
+            .GetInterfaces()
+            .FirstOrDefault(type => type.IsGenericType && typeof(IJobIntroService).IsAssignableFrom(type));
+
+        return (genericInterface is not null
+            ? genericInterface.GetGenericArguments()[0]
+            : serviceToRegister, serviceToRegister);
+    }
+
+    private static ServiceLifetime GetLifetime(Type serviceToRegister)
+    {
+        var lifetime = ServiceLifetime.Transient;
+
+        if (typeof(IScoped).IsAssignableFrom(serviceToRegister))
+            lifetime = ServiceLifetime.Scoped;
+        else if (typeof(ISingleton).IsAssignableFrom(serviceToRegister)) 
+            lifetime = ServiceLifetime.Singleton;
+
+        return lifetime;
+    }
+
+    private static IEnumerable<Assembly> FilterAssemblies(params Assembly[] assemblies)
+    {
+        var currentAssembly = Assembly.GetAssembly(typeof(IJobIntroService));
+
+        return assemblies.Where(x => x.FullName != currentAssembly?.FullName);
+    }
+    
+    private static IServiceCollection AddService(this IServiceCollection services, params Assembly[] assemblies)
+    {
+        var compatibleAssemblies = FilterAssemblies(assemblies);
+
+        var servicesToRegister = compatibleAssemblies
+            .SelectMany(x => x.GetTypes())
+            .Where(t => typeof(IJobIntroService).IsAssignableFrom(t))
+            .ToList();
+
+        foreach (var serviceToRegister in servicesToRegister)
+        {
+            var (serviceType, implementationType) = GetTypes(serviceToRegister);
+            var lifetime = GetLifetime(serviceToRegister);
+
+            if (typeof(IHasImplementationFactory).IsAssignableFrom(serviceToRegister))
+                RegisterWithImplementationFactory(services, implementationType, lifetime);
+            else
+                RegisterWithTypes(services, serviceType, implementationType, lifetime);
+        }
+
+        return services;
+    }
+}


### PR DESCRIPTION
**I have written a small extension that will be useful for C# service registration in the future.**

### How to use

Example: Suppose you want to register a service called "HomeService" with an interface called "IHomeService" as a transient service.
`class HomeService: IHomeService, ITransient<IHomeService>`

The above interface basically saves you from this syntax in Startup.cs
`services.AddTransient<IHomeService,HomeService>();`

Another example is, say you want to register "HomeService" without an interface. Just inherit the ITransient interface.
`class HomeService: ITransient`

Below is the Startup.cs equivalent.
`services.AddTransient<HomeService>();`


### How to setup?
```
// Register ( how ironic ) Serviced in your Startup.cs
services.AddService(typeof(Startup).Assembly);
```
Pass as parameters the assemblies in which our services are located. We can pass multiple assemblies or just one.